### PR TITLE
Show Report の精度を milliseconds から nanoseconds に変更

### DIFF
--- a/src/Dealer/DealReporter.cpp
+++ b/src/Dealer/DealReporter.cpp
@@ -42,11 +42,11 @@ void DealReporter::ShowReports(const std::vector<DealReport> &reports,
                                std::chrono::time_point<std::chrono::system_clock> rangeStart,
                                std::chrono::time_point<std::chrono::system_clock> rangeEnd)
 {
-    auto range = std::chrono::duration_cast<std::chrono::milliseconds>(rangeEnd - rangeStart).count();
-    auto rangeSecondsAsDouble = range / 1000.0;
+    auto range = std::chrono::duration_cast<std::chrono::nanoseconds>(rangeEnd - rangeStart).count();
+    auto rangeSecondsAsDouble = range / 1'000'000'000.0;
     auto totalSize = std::accumulate(reports.begin(), reports.end(), 0,
                                      [](int sum, const DealReport &report) { return sum + report.PacketSize(); });
-    auto totalSizeKiloBits = totalSize * 8 / 1000.0;
+    auto totalSizeKiloBits = totalSize * 8 / 1'000.0;
     auto throughput = totalSizeKiloBits / rangeSecondsAsDouble;
     auto packetPerSecond = reports.size() / rangeSecondsAsDouble;
 


### PR DESCRIPTION
#13 

nsec 精度を超えることはないものとする．  
// nsec 精度を超えることを想定すると `if` を増やすことになる．実用上 nsec を超える可能性と `if` 1 回分の命令コストを比較したとき `if` を減らすほうが有用と判断した．