### PR TITLE
--report-interval が 0 もしくは負値の場合は Reporter を無効化する

### DIFF
--- a/src/Dealer/DealReporter.cpp
+++ b/src/Dealer/DealReporter.cpp
@@ -7,6 +7,12 @@ DealReporter::DealReporter(Dealer &dealer, std::chrono::milliseconds interval) :
 
 void DealReporter::operator()()
 {
+    if (_Interval.count() <= 0)
+    {
+        spdlog::info("A deal reporter is disabled. The interval is zero or negative.");
+        return;
+    }
+
     auto showReportsReservation = std::chrono::system_clock::now() + _Interval;
 
     while (true)


### PR DESCRIPTION
0 を入力

```
$ sudo ./build/TrafficPlayer --log-level info -i lo -p ~/Downloads/dns.cap --report-interval 0 --repeat 0 throughput 1
[2024-11-29 00:54:52.822] [info] Throughput: 1 Mbps
[2024-11-29 00:54:52.823] [info] Mode: Throughput
[2024-11-29 00:54:52.857] [info] A deal reporter is disabled. The interval is zero or negative.
```

---

負値を入力

```
$ sudo ./build/TrafficPlayer --log-level info -i lo -p ~/Downloads/dns.cap --report-interval -1 --repeat 0 throughput 1
[2024-11-29 00:56:09.044] [info] Throughput: 1 Mbps
[2024-11-29 00:56:09.044] [info] Mode: Throughput
[2024-11-29 00:56:09.069] [info] A deal reporter is disabled. The interval is zero or negative.
```